### PR TITLE
Fixed syntax errors, and namespaces

### DIFF
--- a/actions.py
+++ b/actions.py
@@ -19,10 +19,10 @@ def move_out_starbucks():
         #d.spinLeft(100, 2500)
 
         
-def follow_gray_line():        
+def follow_gray_line(dist):        
         w.set_create_distance(0)
-                                                                                                                                             while w.get_create_distance() < int(sys.argv[1]): # using argv for testing, NOT FINAL CODE
-                #print w.get_create_lcliff_amt()
+        	while w.get_create_distance() < dist:
+				#print w.get_create_lcliff_amt()
                 print w.get_create_distance()
                 if w.get_create_rfcliff_amt() < c.CREATE_BLACK:
                         w.create_drive_direct(100, 0)
@@ -30,8 +30,9 @@ def follow_gray_line():
                         w.create_drive_direct(0, 100)
                 print "Done! on the line"      
 
-def follow_black_line():
+def follow_black_line(dist):
         w.set_create_distance(0)
+		while w.get_create_distance() < dist:
                 print w.get_create_distance
                 if e.get_create_rcliff_amt() > c.CREATE_BLACK:
                         w.create_drive_direct(0,100)

--- a/actions.py
+++ b/actions.py
@@ -25,20 +25,20 @@ def follow_gray_line(dist):
 				#print w.get_create_lcliff_amt()
                 print w.get_create_distance()
                 if w.get_create_rfcliff_amt() < c.CREATE_BLACK:
-                        w.create_drive_direct(100, 0)
+                    w.create_drive_direct(100, 0)
                 elif w.get_create_lfcliff_amt() < c.CREATE_BLACK:
-                        w.create_drive_direct(0, 100)
+                    w.create_drive_direct(0, 100)
                 print "Done! on the line"      
 
 def follow_black_line(dist):
         w.set_create_distance(0)
 		while w.get_create_distance() < dist:
-                print w.get_create_distance
-                if e.get_create_rcliff_amt() > c.CREATE_BLACK:
-                        w.create_drive_direct(0,100)
-                elif w.get_create_lfcliff_amt() > c.CREATE_BLACK:
-                        w.create_drive_direct(100,0)
-                print "samadisnumber1"
+            print w.get_create_distance
+            if w.get_create_rcliff_amt() > c.CREATE_BLACK:
+                w.create_drive_direct(0,100)
+            elif w.get_create_lfcliff_amt() > c.CREATE_BLACK:
+                w.create_drive_direct(100,0)
+            print "samadisnumber1"
                 
 
  

--- a/actions.py
+++ b/actions.py
@@ -34,9 +34,9 @@ def follow_black_line(dist):
         w.set_create_distance(0)
 		while w.get_create_distance() < dist:
             print w.get_create_distance
-            if w.get_create_rcliff_amt() > c.CREATE_BLACK:
+            if w.get_create_rcliff_amt() < c.CREATE_BLACK:
                 w.create_drive_direct(0,100)
-            elif w.get_create_lfcliff_amt() > c.CREATE_BLACK:
+            elif w.get_create_lfcliff_amt() < c.CREATE_BLACK:
                 w.create_drive_direct(100,0)
             print "samadisnumber1"
                 

--- a/main.py
+++ b/main.py
@@ -14,8 +14,10 @@ def main():
 	# w.shut_down_in(120)
 
 	a.move_out_starbucks() # move out of start box
-	a.follow_gray_line()\
-        a.follow_black_line()\
+	# ARGV PARAMETERS ARE NOT FINAL CODE!
+	a.follow_gray_line(int(sys.argv[1])) # putting this in so we can play with values 
+        a.follow_black_line(int(sys.argv[2])) # putting this in so we can play with values
+
 	
 	w.create_disconnect()
 

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ def main():
 	a.move_out_starbucks() # move out of start box
 	# ARGV PARAMETERS ARE NOT FINAL CODE!
 	a.follow_gray_line(int(sys.argv[1])) # putting this in so we can play with values 
-        a.follow_black_line(int(sys.argv[2])) # putting this in so we can play with values
+	a.follow_black_line(int(sys.argv[2])) # putting this in so we can play with values
 
 	
 	w.create_disconnect()


### PR DESCRIPTION
1. I removed the slashes at the end of lines 17 & 18 in main.py, this would probably error out.
2. I changed the `follow_gray_line` and `follow_black_line` functions so we could pass in a parameter of how long we wanted to line follow them. _I'm using argv for testing_
Before, you were clearing the distance counter like you were going to track the distance and indenting, but actually nothing was being run.
3. Changed `e.get_create_rfcliff_amt()` to `w.get_create_rfcliff_amt()`, you had an incorrect prefix
4. Changed the greater than sign to a less than sign in `follow_black_line` because less than means we are ON the line, and greater than means we are not. _Maybe we can write a function that clears all of that up?_

Feel free to look over these changes, and **smash** that merge pull request button!